### PR TITLE
Add option to ignore JSON media type for link headers

### DIFF
--- a/test/JsonLdParser-test.ts
+++ b/test/JsonLdParser-test.ts
@@ -36,6 +36,18 @@ describe('JsonLdParser', () => {
         ERROR_CODES.LOADING_DOCUMENT_FAILED))
     });
 
+    it('should handle a plain JSON response when ignoreJSONMediaType is true', () => {
+      const parser = JsonLdParser.fromHttpResponse('BASE', 'application/json', undefined, { ignoreJSONMediaType: true });
+      expect((<any> parser).options.baseIRI).toEqual('BASE');
+    });
+
+
+    it('should error on a JSON extension type even with ignoreJSONMediaType', () => {
+      expect(() => JsonLdParser.fromHttpResponse('BASE', 'text/turtle+json', undefined, { ignoreJSONMediaType: true }))
+        .toThrow(new ErrorCoded(`Missing context link header for media type text/turtle+json on BASE`,
+          ERROR_CODES.LOADING_DOCUMENT_FAILED))
+    });
+
     it('should error on a JSON extension type without link header', () => {
       expect(() => JsonLdParser.fromHttpResponse('BASE', 'text/turtle+json'))
         .toThrow(new ErrorCoded(`Missing context link header for media type text/turtle+json on BASE`,


### PR DESCRIPTION
Well the logic of this is done. You may have some better thoughts on the name of the option, or a better description. 

The next steps would be to add this option as a [context](https://comunica.dev/docs/query/advanced/context/) option in Comunica, and add it to `@comunica/actor-rdf-parse-jsonld`. That would need a new release of this library.

Closes #70 