### PR TITLE
feat: use @bergos/jsonparse to remove requirement for bundler config

### DIFF
--- a/lib/JsonLdParser.ts
+++ b/lib/JsonLdParser.ts
@@ -1,6 +1,6 @@
 import * as RDF from "@rdfjs/types";
 // tslint:disable-next-line:no-var-requires
-const Parser = require('jsonparse');
+const Parser = require('@bergos/jsonparse');
 import {ERROR_CODES, ErrorCoded, IDocumentLoader, JsonLdContext, Util as ContextUtil} from "jsonld-context-parser";
 import {PassThrough, Transform, Readable} from "readable-stream";
 import {EntryHandlerArrayValue} from "./entryhandler/EntryHandlerArrayValue";

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "index.js"
   ],
   "dependencies": {
+    "@bergos/jsonparse": "^1.4.0",
     "@rdfjs/types": "*",
     "@types/http-link-header": "^1.0.1",
     "@types/readable-stream": "^2.3.13",
@@ -38,7 +39,6 @@
     "canonicalize": "^1.0.1",
     "http-link-header": "^1.0.2",
     "jsonld-context-parser": "^2.1.3",
-    "jsonparse": "^1.3.1",
     "rdf-data-factory": "^1.1.0",
     "readable-stream": "^4.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,6 +284,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@bergos/jsonparse@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@bergos/jsonparse/-/jsonparse-1.4.0.tgz#b41a00341d27da39099ac564d57b193a2f1b9741"
+  integrity sha512-inR67ZG/CC2l4vIl73olg1m+mvYJyZLL6C5OhwSxFNLMx0UwIRy7XnJKgrrriZ9ZZ5JDPQrW7cS2UvQb3YgeiA==
+  dependencies:
+    buffer "^6.0.3"
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"


### PR DESCRIPTION
This PR removes the requirement for a bundler config for a `buffer` polyfill. A fork of [jsonparse](https://github.com/bergos/jsonparse/) is used to add the `buffer` dependency and `require` it in the code.

fixes #105